### PR TITLE
Type sizes to fix intermittent issues with CreateProcess

### DIFF
--- a/TikiLoader/Loader.cs
+++ b/TikiLoader/Loader.cs
@@ -136,6 +136,7 @@ namespace TikiLoader
             STARTUPINFOEX sInfoEx = new STARTUPINFOEX();
             PROCESS_INFORMATION pInfo = new PROCESS_INFORMATION();
 
+            sInfoEx.StartupInfo.cb = (uint)Marshal.SizeOf(sInfoEx);
             IntPtr lpValue = IntPtr.Zero;
 
             try
@@ -143,6 +144,8 @@ namespace TikiLoader
 
                 SECURITY_ATTRIBUTES pSec = new SECURITY_ATTRIBUTES();
                 SECURITY_ATTRIBUTES tSec = new SECURITY_ATTRIBUTES();
+                pSec.nLength = Marshal.SizeOf(pSec);
+                tSec.nLength = Marshal.SizeOf(tSec);
 
                 uint flags = CreateSuspended | DetachedProcess | CreateNoWindow | EXTENDED_STARTUPINFO_PRESENT;
 


### PR DESCRIPTION
Was seeing a few intermittent issues where CreateProcess was failing when running in certain contexts. Setting the sizes for these types before calling CreateProcess remediates the issue.